### PR TITLE
Override elliptic to 6.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5666,10 +5666,11 @@
       "dev": true
     },
     "node_modules/elliptic": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.0.tgz",
-      "integrity": "sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "stylelint-order": "^6.0.4",
     "stylelint-scss": "^6.7.0",
     "supertest": "^4.0.2"
+  },
+  "overrides": {
+    "elliptic": "6.6.1"
   }
 }


### PR DESCRIPTION
See this alert: https://github.com/businessandtrade-partners/spl-eligibility-tool/security/dependabot/96